### PR TITLE
Set up custom domain for production deployment of figure GH pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+figure.openmicroscopy.org

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
 name: Your New Jekyll Site
 markdown: redcarpet
 pygments: true
-baseurl: /figure
+baseurl: ''


### PR DESCRIPTION
This should allow to publish the figure GH pages under figure.openmicroscopy.org /cc @kennethgillen @will-moore @joshmoore @hflynn @gusferguson