### PR TITLE
GitHub pages preparation for switch to master branch

### DIFF
--- a/_includes/github_ticker.html
+++ b/_includes/github_ticker.html
@@ -148,7 +148,7 @@
       </div>
       <div class="github_ticker inner" style="top: -80px; overflow: visible" title="Recent commits to OMERO.figure on GitHub">
         <ul class="ticker_title_right">
-          <li><a href="https://github.com/ome/figure/commits/develop">See all commits</a></li>
+          <li><a href="https://github.com/ome/figure/commits/master">See all commits</a></li>
         </ul>
       </div>
     </div>

--- a/_posts/2014-08-17-dev-jst-templates.markdown
+++ b/_posts/2014-08-17-dev-jst-templates.markdown
@@ -15,11 +15,11 @@ to use on a dedicated test page without copying and pasting the code elsewhere.
 
 Googling for "backbone templates in separate files" led me to this [stack overflow answer](http://stackoverflow.com/questions/8366733/external-template-in-underscore)
 which recommended the use of "a grunt task (grunt-contrib-jst) to compile all of the HTML templates into a single templates.js file".
-So that's what I did. Now all the html templates live under [static/figure/templates](https://github.com/will-moore/figure/tree/develop/static/figure/templates) and are compiled into a single <code style="display:inline">templates.js</code> file by a grunt 'jst' task.
+So that's what I did. Now all the html templates live under [static/figure/templates](https://github.com/will-moore/figure/tree/master/static/figure/templates) and are compiled into a single <code style="display:inline">templates.js</code> file by a grunt 'jst' task.
 
 I also added a grunt 'watch' task to monitor changes to any of the template files and recompile
 them all if any changes are saved. So if you are editing any templates you need to have '$ grunt watch'
-running on the command line. All that is configured in the [Gruntfile.js ](https://github.com/will-moore/figure/blob/develop/Gruntfile.js).
+running on the command line. All that is configured in the [Gruntfile.js ](https://github.com/will-moore/figure/blob/master/Gruntfile.js).
 
 Most importantly, this allowed me to create the viewer test page and to fix the bug,
 but it also means that the templates are


### PR DESCRIPTION
Now that `master` and `develop` are in sync, we can switch to the default Git master branch as the development branch. If so, this PR modifies the GH pages resources to point at the commits on this branch instead of the develop one.

/cc @hflynn