### PR TITLE
Readme url fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ OMERO.figure
 
 OMERO.web app for creating figures from images in OMERO.
 
-For full details see http://will-moore.github.io/figure/
+For full details see http://figure.openmicroscopy.org
 
 
 Requirements
@@ -14,14 +14,14 @@ Requirements
 Installation
 ============
 
-Please see instructions at http://will-moore.github.io/figure/
+Please see instructions at http://figure.openmicroscopy.org
 
 
 Development
 ===========
 
 We use Grunt for various tools.
-See http://will-moore.github.io/figure/2014/05/01/testing-with-jshint-jasmine-grunt.html
+See http://figure.openmicroscopy.org/2014/05/01/testing-with-jshint-jasmine-grunt.html
 for an introduction.
 
 Install:

--- a/templates/figure/index.html
+++ b/templates/figure/index.html
@@ -111,7 +111,7 @@
                 <div class="modal-body" style="padding: 25px 25px 35px 25px; text-align:center">
                     <p><strong>Version</strong>: <script>document.write(RELEASE_VERSION)</script></p>
                     <p>For more information, visit the
-                        <a target="new" href="http://will-moore.github.io/figure/">OMERO.figure Home Page</a>
+                        <a target="new" href="http://figure.openmicroscopy.org">OMERO.figure Home Page</a>
                     </p>
                     <p>
                         &copy; 2013-{% now "Y" %} University of Dundee &amp; Open Microscopy Environment<br/>
@@ -544,7 +544,7 @@
                                 <a href="#">About OMERO.figure</a>
                             </li>
                             <li>
-                                <a href="http://will-moore.github.io/figure/" target="new">
+                                <a href="http://figure.openmicroscopy.org" target="new">
                                     Home Page
                                 </a>
                             </li>


### PR DESCRIPTION
These 2 commits were already in "develop" but not in "master" since they got left behind around the time we switch main branch from "develop" to "master".

This was noticed by @jburel because the new Shapes PR: #100 is based off "develop" and contains these commits that should really be handled separately.