### PR TITLE
Fix the resize of paper

### DIFF
--- a/static/figure/js/models/figure_model.js
+++ b/static/figure/js/models/figure_model.js
@@ -15,8 +15,8 @@
             'canvas_width': 13000,
             'canvas_height': 8000,
             // w & h from reportlab.
-            'paper_width': 612,
-            'paper_height': 792,
+            'paper_width': 595,
+            'paper_height': 842,
             'page_count': 1,
             'page_col_count': 1,    // pages laid out in grid
             'paper_spacing': 50,    // between each page


### PR DESCRIPTION
Noticed by @gusferguson and reported in https://github.com/ome/figure/pull/102#issuecomment-141024626
Since the size of A4 is 210 x 297 mm, (8.27 x 11.7 inches) at 72 dpi this is
595 x 842 points, so we need to start at this size so that we see no change when we
save 'paper setup', e.g. changing page count.
See https://en.wikipedia.org/wiki/Paper_size

To test:
 - Create a new figure, add a panel and place at the bottom right of the page (to mark page size).
 - Then edit "Paper setup", e.g. set page count to 2 and Save.
 - Should see no change in size of page.