### PR TITLE
Fixing imgData

### DIFF
--- a/views.py
+++ b/views.py
@@ -120,14 +120,14 @@ def shape_editor(request, conn=None, **kwargs):
 def imgData_json(request, imageId, conn=None, **kwargs):
 
     image = conn.getObject("Image", imageId)
+    if image is None:
+        raise Http404("Image not found")
 
     # Test if we have Units support (OMERO 5.1)
     px = image.getPrimaryPixels().getPhysicalSizeX()
     pixSizeX = str(px)  # As string E.g. "0.13262 MICROMETER"
     unitsSupport = " " in pixSizeX
 
-    if image is None:
-        raise Http404("Image not found")
     rv = imageMarshal(image)
 
     if unitsSupport:

--- a/views.py
+++ b/views.py
@@ -128,7 +128,7 @@ def imgData_json(request, imageId, conn=None, **kwargs):
     pixSizeX = str(px)  # As string E.g. "0.13262 MICROMETER"
     unitsSupport = " " in pixSizeX
 
-    rv = imageMarshal(image)
+    rv = imageMarshal(image, request=request)
 
     if unitsSupport:
         rv['pixel_size']['symbolX'] = px.getSymbol()


### PR DESCRIPTION
This fixes:
- imgData when image is not found. Previously it throws:
```
  File "/home/hudson/OMERO.webapps/figure/views.py", line 125, in imgData_json
    px = image.getPrimaryPixels().getPhysicalSizeX()

AttributeError: 'NoneType' object has no attribute 'getPrimaryPixels'
```
- add request to imageMarshal to make sure server settings are loaded