### PR TITLE
Add support for Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.*un~
+*.pyc
+.DS_Store
+demo/static/figure/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:4.2
+
+RUN adduser figure
+COPY . /home/figure/src
+RUN chown -R figure /home/figure/src
+USER figure
+WORKDIR /home/figure/src
+
+RUN npm install
+RUN npm install grunt-cli
+RUN $(npm bin)/grunt demo
+
+WORKDIR /home/figure/src/demo
+CMD ["python", "-m", "SimpleHTTPServer"]

--- a/README.md
+++ b/README.md
@@ -43,3 +43,26 @@ And to have this run whenever templates are edited:
 
 	$ grunt watch
 
+To update the demo figure app at http://figure.openmicroscopy.org/demo/
+we have a grunt task that concats and moves js files into demo/.
+It also replaces Django template tags in index.html and various js code
+fragments with static app code. This is all handled by the grunt task:
+
+    $ grunt demo
+
+This puts everything into the figure/demo/ directory.
+This can be tested locally via:
+
+    $ cd demo/
+    $ python -m SimpleHTTPServer
+
+Go to http://localhost:8000/ to test it.
+To update the figure.openmicroscopy.org site:
+
+    - Copy the demo directory and replace the demo directory in gh-pages-staging branch.
+    - Commit changes and open PR against ome/gh-pages-staging as described https://github.com/ome/figure/tree/gh-pages-staging
+
+It is also possible to run the demo in docker without installing anything locally:
+
+    $ docker build -t figure-demo .
+    $ docker run -ti --rm -p 8000:8000 figure-demo


### PR DESCRIPTION
As requested in https://github.com/ome/figure/pull/107, opening as a new PR. This allows testing figure's demo task without the need for installing anything locally.