### PR TITLE
Add support for Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 *.pyc
 .DS_Store
 demo/static/figure/
+node_modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.*un~
+*.pyc
+.DS_Store
+demo/static/figure/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:4.2
+
+RUN adduser figure
+COPY . /home/figure/src
+RUN chown -R figure /home/figure/src
+USER figure
+WORKDIR /home/figure/src
+
+RUN npm install
+RUN npm install grunt-cli
+RUN $(npm bin)/grunt demo
+
+WORKDIR /home/figure/src/demo
+CMD ["python", "-m", "SimpleHTTPServer"]

--- a/README.md
+++ b/README.md
@@ -56,3 +56,8 @@ To update the figure.openmicroscopy.org site:
 
     - Copy the demo directory and replace the demo directory in gh-pages-staging branch.
     - Commit changes and open PR against ome/gh-pages-staging as described https://github.com/ome/figure/tree/gh-pages-staging
+
+It is also possible to run the demo in docker without installing anything locally:
+
+    $ docker build -t figure-demo .
+    $ docker run -ti --rm -p 8000:8000 figure-demo

--- a/README.md
+++ b/README.md
@@ -61,3 +61,11 @@ It is also possible to run the demo in docker without installing anything locall
 
     $ docker build -t figure-demo .
     $ docker run -ti --rm -p 8000:8000 figure-demo
+
+If you are using docker-machine (e.g. on Mac OS X or Windows), you can find the URL of your demo with:
+
+    # get the ip address of your docker machine (named default)
+    $ docker-machine ip default
+    192.168.99.100
+    # Now check the result in your browser at:
+    http://192.168.99.100:8000/


### PR DESCRIPTION
As requested in https://github.com/ome/figure/pull/107, opening as a new PR. This allows testing figure's demo task without the need for installing anything locally.