### PR TITLE
Render thumbnail 404s

### DIFF
--- a/static/figure/css/figure.css
+++ b/static/figure/css/figure.css
@@ -686,6 +686,10 @@
         height: 40px;
     }
 
+    .missingThumb {
+        background: #eeeeee;
+    }
+
     .table-sort-btn {
         padding-left: 3px;
         padding-right: 3px;

--- a/static/figure/js/templates.js
+++ b/static/figure/js/templates.js
@@ -340,7 +340,8 @@ with (obj) {
 __p += '\n    ';
  if (disabled) { ;
 __p += '\n        <td>\n            ';
- if(imageId > 0) { print("<img class='small-thumb' src='" + thumbSrc + "' />") } ;
+ if(imageId > 0) { print("<img class='small-thumb' src='" + thumbSrc + "' />") }
+               else { print ("<div class='missingThumb small-thumb'></div>")} ;
 __p += '\n        </td>\n        <td title="This figure is currently open">\n            <div style="width:400px; word-wrap:break-word;">\n                ' +
 ((__t = ( name )) == null ? '' : __t) +
 '\n            </div>\n        </td>\n    ';
@@ -348,7 +349,8 @@ __p += '\n        </td>\n        <td title="This figure is currently open">\n   
 __p += '\n        <td>\n            <a href="' +
 ((__t = ( url )) == null ? '' : __t) +
 '">\n                ';
- if(imageId > 0) { print("<img class='small-thumb' src='" + thumbSrc + "' />") } ;
+ if(imageId > 0) { print("<img class='small-thumb' src='" + thumbSrc + "' />") } 
+                    else { print ("<div class='missingThumb small-thumb'></div>")} ;
 __p += '\n            </a>\n        </td>\n        <td>\n            <div style="width:400px; word-wrap:break-word;">\n                <a href="' +
 ((__t = ( url )) == null ? '' : __t) +
 '">' +

--- a/static/figure/templates/files/figure_file_item.html
+++ b/static/figure/templates/files/figure_file_item.html
@@ -1,7 +1,8 @@
 
     <% if (disabled) { %>
         <td>
-            <% if(imageId > 0) { print("<img class='small-thumb' src='" + thumbSrc + "' />") } %>
+            <% if(imageId > 0) { print("<img class='small-thumb' src='" + thumbSrc + "' />") }
+               else { print ("<div class='missingThumb small-thumb'></div>")} %>
         </td>
         <td title="This figure is currently open">
             <div style="width:400px; word-wrap:break-word;">
@@ -11,7 +12,8 @@
     <% } else { %>
         <td>
             <a href="<%= url %>">
-                <% if(imageId > 0) { print("<img class='small-thumb' src='" + thumbSrc + "' />") } %>
+                <% if(imageId > 0) { print("<img class='small-thumb' src='" + thumbSrc + "' />") } 
+                    else { print ("<div class='missingThumb small-thumb'></div>")} %>
             </a>
         </td>
         <td>

--- a/views.py
+++ b/views.py
@@ -402,7 +402,7 @@ def list_web_figures(request, conn=None, **kwargs):
 
         rsp.append(figFile)
 
-    # remove image Ids if images no longer exist (to prevent 404 for thumbnails)
+    # remove image Ids if images deleted (to prevent 404 for thumbnails)
     params = omero.sys.ParametersI()
     params.addIds(list(thumbIds))
     query = "select i.id from Image i where i.id in (:ids)"

--- a/views.py
+++ b/views.py
@@ -408,13 +408,6 @@ def list_web_figures(request, conn=None, **kwargs):
     query = "select i.id from Image i where i.id in (:ids)"
     rslt = conn.getQueryService().projection(query, params, conn.SERVICE_OPTS)
     ids = [unwrap(r)[0] for r in rslt]
-    print ids
-
-    print len(thumbIds)
-    print len(ids)
-
-    # {"thumbIds": len(thumbIds), "ids": len(ids)}
-
     for fig in rsp:
         if 'description' in fig:
             desc = fig['description']

--- a/views.py
+++ b/views.py
@@ -26,7 +26,7 @@ import time
 from omeroweb.webgateway.marshal import imageMarshal
 from omeroweb.webclient.views import run_script
 from django.core.urlresolvers import reverse
-from omero.rtypes import wrap, rlong, rstring
+from omero.rtypes import wrap, rlong, rstring, unwrap
 import omero
 from omero.gateway import OriginalFileWrapper
 
@@ -374,6 +374,7 @@ def list_web_figures(request, conn=None, **kwargs):
     # fileAnns.sort(key=lambda x: x.creationEventDate(), reverse=True)
 
     rsp = []
+    thumbIds = set()
     for fa in fileAnns:
         owner = fa.getDetails().getOwner()
         cd = fa.creationEventDate()
@@ -394,12 +395,32 @@ def list_web_figures(request, conn=None, **kwargs):
             # Overwrite the file name. (json supports unicode file name)
             if 'name' in description:
                 figFile['name'] = description['name']
+            if 'imageId' in description:
+                thumbIds.add(description['imageId'])
         except:
             pass
 
         rsp.append(figFile)
 
-    rsp.sort(key=lambda x: x['name'].lower())
+    # remove image Ids if images no longer exist (to prevent 404 for thumbnails)
+    params = omero.sys.ParametersI()
+    params.addIds(list(thumbIds))
+    query = "select i.id from Image i where i.id in (:ids)"
+    rslt = conn.getQueryService().projection(query, params, conn.SERVICE_OPTS)
+    ids = [unwrap(r)[0] for r in rslt]
+    print ids
+
+    print len(thumbIds)
+    print len(ids)
+
+    # {"thumbIds": len(thumbIds), "ids": len(ids)}
+
+    for fig in rsp:
+        if 'description' in fig:
+            desc = fig['description']
+            if 'imageId' in desc:
+                if desc['imageId'] not in ids and 'baseUrl' not in desc:
+                    desc['imageId'] = -1
 
     return HttpResponse(json.dumps(rsp), content_type='json')
 


### PR DESCRIPTION
This fixes the numerous 404 warnings caused by trying to use thumbnails from deleted images in the figure File > Open dialog.
E.g. nightshade:
```
Referrer: https://nightshade.openmicroscopy.org/figure/file/357017
Requested URL: /webgateway/render_thumbnail/3967151/
```

To test:
 - Pick an image that you are happy to delete, add it into a new figure and save the figure.
 - File > Open dialog should show the image thumbnail beside the new file in the list.
 - Now delete the image (in webclient). 
 - Return to /figure/ app and refresh the page, then File > Open again.
 - Should see a grey thumbnail placeholder and if you check browser devtools you should see no 404 for render_thumbnail url.

![screen shot 2015-11-08 at 21 44 02](https://cloud.githubusercontent.com/assets/900055/11022854/f3588a8c-8661-11e5-9eae-867e39c890bd.png)