### PR TITLE
Set line width as number, not string

### DIFF
--- a/static/figure/js/views/right_panel_view.js
+++ b/static/figure/js/views/right_panel_view.js
@@ -83,6 +83,7 @@
         changeLineWidth: function() {
             var width = $('button.line-width span:first', this.$el).attr('data-line-width'),
                 sel = this.model.getSelected();
+            width = parseInt(width, 10);
 
             sel.forEach(function(panel){
                 panel.setROIStrokeWidth(width);


### PR DESCRIPTION
Fixes a bug with setting line width using the controls at the top of Labels tab (which only showed as a bug when exporting the figure to PDF).
NB: I need to manually upload the export script to eel for this to be tested (export enabled).

To test:
 - Create an ROI then use the line-width drop down at top of Labels tab to change line width.
 - Try exporting as PDF.