### PR TITLE
Fix zero division error in export script drawArrow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figure",
-  "version": "1.2.0-rc2",
+  "version": "1.2.0-rc3",
   "description": "OMERO figure creation app",
   "main": "index.js",
   "scripts": {

--- a/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -277,7 +277,10 @@ class ShapeToPdfExport(object):
 
         p = self.canvas.beginPath()
 
-        lineAngle = atan(dx / dy)
+        if dy == 0:
+            lineAngle = radians(90)
+        else:
+            lineAngle = atan(dx / dy)
         f = -1
         if dy < 0:
             f = 1
@@ -429,7 +432,10 @@ class ShapeToPilExport(object):
         # Do some trigonometry to get the line angle can calculate arrow points
         dx = x2 - x1
         dy = y2 - y1
-        lineAngle = atan(dx / dy)
+        if dy == 0:
+            lineAngle = radians(90)
+        else:
+            lineAngle = atan(dx / dy)
         f = -1
         if dy < 0:
             f = 1

--- a/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -276,14 +276,15 @@ class ShapeToPdfExport(object):
         self.canvas.setLineWidth(strokeWidth)
 
         p = self.canvas.beginPath()
-
+        f = -1
         if dy == 0:
             lineAngle = radians(90)
+            if dx < 0:
+                f = 1
         else:
             lineAngle = atan(dx / dy)
-        f = -1
-        if dy < 0:
-            f = 1
+            if dy < 0:
+                f = 1
 
         # Angle of arrow head is 0.8 radians (0.4 either side of lineAngle)
         arrowPoint1x = x2 + (f * sin(lineAngle - 0.4) * headSize)

--- a/templates/figure/index.html
+++ b/templates/figure/index.html
@@ -39,7 +39,7 @@
 
     <script>
 
-    var RELEASE_VERSION = "v1.2.0-rc2";
+    var RELEASE_VERSION = "v1.2.0-rc3";
 
     var BASE_WEBFIGURE_URL = "{% url 'figure_index' %}",
         SAVE_WEBFIGURE_URL = "{% url 'save_web_figure' %}",


### PR DESCRIPTION
Fix bug in export when arrows are horizontal:

```
    ShapeToPdfExport(self.figureCanvas, panel, page, crop, self.pageHeight)
  File "./script", line 117, in __init__
    self.drawArrow(shape)
  File "./script", line 280, in drawArrow
    lineAngle = atan(dx / dy)
ZeroDivisionError: float division by zero
```
To test, draw horizontal arrow and try exporting figure as PDF and TIFF.