### PR TITLE
Adding 'lightweight' and updating warning in 1.2.0 blog post

### DIFF
--- a/_posts/2015-11-24-release-1.2.0.markdown
+++ b/_posts/2015-11-24-release-1.2.0.markdown
@@ -5,7 +5,7 @@ date:   2015-11-24
 ---
 
 We are pleased to announce the release of OMERO.figure 1.2.0.
-This release introduces support for lightweight ROIs on figure panels.
+This release introduces support for illustrative ROIs on figure panels.
 
 **NB:** ROIs drawn in OMERO.figure cannot yet be saved as new ROIs on the OMERO server and it is not yet possible to load ROIs from OMERO to use in OMERO.figure.
 

--- a/_posts/2015-11-24-release-1.2.0.markdown
+++ b/_posts/2015-11-24-release-1.2.0.markdown
@@ -5,7 +5,9 @@ date:   2015-11-24
 ---
 
 We are pleased to announce the release of OMERO.figure 1.2.0.
-This release introduces support for ROIs on figure panels.
+This release introduces support for lightweight ROIs on figure panels.
+
+**NB:** ROIs drawn in OMERO.figure cannot yet be saved as new ROIs on the OMERO server and it is not yet possible to load ROIs from OMERO to use in OMERO.figure.
 
 <h3>Key features</h3>
 
@@ -13,7 +15,6 @@ This release introduces support for ROIs on figure panels.
  - Currently supports rectangle, line, arrow and ellipse
  - ROIs can be copied and pasted between panels
  - Rectangles can be pasted as a crop region on another panel
- - **NB:** ROIs drawn in OMERO.figure cannot be saved as new ROIs on the OMERO server and it is not yet possible to load ROIs from OMERO to use in OMERO.figure.
 
 Many of the new ROI features and workflows are described in the [previous blog post]({{ site.baseurl }}/2015/11/09/try-new-roi-features-on-the-demo-app.html) and a full demonstration of these new features can be viewed below:
 


### PR DESCRIPTION
As discussed, make clearer that ROIs are not saved to OMERO.
cc @sbesson @jburel @joshmoore 