### PR TITLE
Remove bin/omero web stop & start from figure docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,11 +143,7 @@ title: OMERO.figure
 
               </code>
             </li>
-            <li>Restart web: 
-              <code>
-                $ bin/omero web stop<br>
-                $ bin/omero web start
-              </code>
+            <li>Restart web. How you do this will depend on how you have deployed OMERO.web.
             </li>
           </ul>
           <h4>To enable PDF generation:</h4>
@@ -204,11 +200,7 @@ title: OMERO.figure
                 NB: If your OMERO.web version is earlier than 5.1.0 then this change
                 will be ignored until you upgrade.
             </li>
-            <li>Restart web:
-              <code>
-                $ bin/omero web stop<br>
-                $ bin/omero web start
-              </code>
+            <li>Restart web. How you do this will depend on how you have deployed OMERO.web.
             </li>
           </ul>
         </p>


### PR DESCRIPTION
As suggested by @jburel, not all users will restart web with ```$ bin/omero web stop``` and ```$ bin/omero web start```. Instead, simply instruct users to restart web according to their deployment setup.