### PR TITLE
Fix flake8 warnings for flake8 2.5.1

### DIFF
--- a/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -970,8 +970,8 @@ class FigureExport(object):
         x = x - page['x']
         y = y - page['y']
 
-        if not ('scalebar' in panel and 'show' in panel['scalebar']
-                and panel['scalebar']['show']):
+        if not ('scalebar' in panel and 'show' in panel['scalebar'] and
+                panel['scalebar']['show']):
             return
 
         if not ('pixel_size_x' in panel and panel['pixel_size_x'] > 0):

--- a/urls.py
+++ b/urls.py
@@ -17,12 +17,12 @@
 #
 
 import django
+from figure import views
 if django.VERSION < (1, 6):
     from django.conf.urls.defaults import url, patterns
 else:
     from django.conf.urls import url, patterns
 
-from figure import views
 
 urlpatterns = patterns(
 

--- a/views.py
+++ b/views.py
@@ -34,10 +34,10 @@ from cStringIO import StringIO
 
 from omeroweb.webclient.decorators import login_required
 
+from figure import settings
+
 JSON_FILEANN_NS = "omero.web.figure.json"
 SCRIPT_PATH = "/omero/figure_scripts/Figure_To_Pdf.py"
-
-from figure import settings
 
 
 def createOriginalFileFromFileObj(


### PR DESCRIPTION
This should restore the Travis status to passing - see https://travis-ci.org/ome/figure/builds/101965790 for the current state. The alternative is to cap the version of flake8 installed in .travis.yml as we do on openmicroscopy.git. I have no strong preference either way.