### PR TITLE
Fix rotation of vertical labels with pillow 3.1.0

### DIFF
--- a/scripts/omero/figure_scripts/Figure_To_Pdf.py
+++ b/scripts/omero/figure_scripts/Figure_To_Pdf.py
@@ -1587,7 +1587,7 @@ class TiffExport(FigureExport):
             tempLabel = Image.new('RGBA', (txt_w, txt_h), (255, 255, 255, 0))
             textdraw = ImageDraw.Draw(tempLabel)
             textdraw.text((0, 0), text, font=font, fill=rgb)
-            w = tempLabel.rotate(90)
+            w = tempLabel.rotate(90, expand=True)
             # Use label as mask, so transparent part is not pasted
             y = y - (w.size[1]/2)
             self.tiffFigure.paste(w, (x, y), mask=w)


### PR DESCRIPTION
This fixes the rotation of vertical labels when exporting as Tiff.
Noticed when testing Pillow 3.1.0 (not a problem on Pillow 2.9.0) See https://github.com/ome/omero-install/pull/86

To test, create a figure with vertical labels and export as Tiff using Pillow 3.1.0 (latest version).
Check vertical labels are in correct position.