### PR TITLE
imgData pixel sizes in custom units, not MICROMETERS

### DIFF
--- a/views.py
+++ b/views.py
@@ -136,9 +136,14 @@ def imgData_json(request, imageId, conn=None, **kwargs):
     rv = imageMarshal(image, request=request)
 
     if unitsSupport:
+        px = image.getPrimaryPixels().getPhysicalSizeX()
+        # overwrite existing x value, which will be in MICROMETERS
+        rv['pixel_size']['x'] = px.getValue()
         rv['pixel_size']['symbolX'] = px.getSymbol()
         rv['pixel_size']['unitX'] = str(px.getUnit())
         py = image.getPrimaryPixels().getPhysicalSizeY()
+        # overwrite existing y value, which will be in MICROMETERS
+        rv['pixel_size']['y'] = py.getValue()
         rv['pixel_size']['symbolY'] = py.getSymbol()
         rv['pixel_size']['unitY'] = str(py.getUnit())
     sizeT = image.getSizeT()


### PR DESCRIPTION
This fixes a bug in OMERO.figure caused by the fix in https://github.com/openmicroscopy/openmicroscopy/pull/4460 and discussed in https://github.com/openmicroscopy/openmicroscopy/pull/4460#issuecomment-181951303.

Since the imgData json from webgateway now alway uses MICROMETERS for pixel size units, when the units are different OMERO.figure needs to use the value for the custom unit.

To test, set the pixel size for an image to use different units as described https://www.openmicroscopy.org/site/support/omero5.2/developers/Python.html#create-image.
Add that image to a figure and see that the pixel size shown in right panel is correct.