### PR TITLE
Release 1.2.1 blog post

### DIFF
--- a/_includes/release_history.html
+++ b/_includes/release_history.html
@@ -3,6 +3,15 @@
   full release announcements:</p>
 
 <h4>
+  <a href="{{ site.baseurl }}/2016/04/13/release-1.2.1.html">
+    1.2.1: {{ "2016-04-13" | date_to_string }}
+  </a>
+</h4>
+<ul>
+  <li>Minor release with improvements to the File > Open dialog</li>
+</ul>
+
+<h4>
   <a href="{{ site.baseurl }}/2015/11/24/release-1.2.0.html">
     1.2.0: {{ "2015-11-24" | date_to_string }}
   </a>

--- a/_includes/release_history.html
+++ b/_includes/release_history.html
@@ -8,7 +8,8 @@
   </a>
 </h4>
 <ul>
-  <li>Minor release with improvements to the File > Open dialog</li>
+  <li>Improvements to performance and filtering in the File > Open dialog</li>
+  <li>Small number of minor bug fixes</li>
 </ul>
 
 <h4>

--- a/_includes/release_history.html
+++ b/_includes/release_history.html
@@ -3,8 +3,8 @@
   full release announcements:</p>
 
 <h4>
-  <a href="{{ site.baseurl }}/2016/04/13/release-1.2.1.html">
-    1.2.1: {{ "2016-04-13" | date_to_string }}
+  <a href="{{ site.baseurl }}/2016/04/20/release-1.2.1.html">
+    1.2.1: {{ "2016-04-20" | date_to_string }}
   </a>
 </h4>
 <ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -92,7 +92,7 @@
           </nav>
 
             <section id="downloads">
-              <a class="zip_download_link" href="http://downloads.openmicroscopy.org/figure/1.2.0/figure-1.2.0.zip">
+              <a class="zip_download_link" href="http://downloads.openmicroscopy.org/latest/figure.zip">
                 Download this project as a .zip file
               </a>
             </section>

--- a/_posts/2016-04-13-release-1.2.1.markdown
+++ b/_posts/2016-04-13-release-1.2.1.markdown
@@ -1,0 +1,23 @@
+---
+layout: post
+title:  "Release: 1.2.1"
+date:   2016-04-13
+---
+
+We are pleased to announce the release of OMERO.figure 1.2.1.
+This is a minor release that contains a small number of bug fixes and
+minor feature improvements.
+
+Features:
+
+ - Faster listing of files in File > Open dialog [#145](https://github.com/ome/figure/pull/145)
+ - Improved filtering of listed files by name [#147](https://github.com/ome/figure/pull/147)
+
+Bug Fixes:
+
+ - Fixes a bug in rotating labels when exporting as tiff [#140](https://github.com/ome/figure/pull/140)
+ - Fixes pixel sizes for images with custom pixel size units (not microns) [#144](https://github.com/ome/figure/pull/144)
+
+
+Grab the release from the OMERO.figure [1.2.1 download page](http://downloads.openmicroscopy.org/figure/1.2.1/).
+

--- a/_posts/2016-04-20-release-1.2.1.markdown
+++ b/_posts/2016-04-20-release-1.2.1.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Release: 1.2.1"
-date:   2016-04-13
+date:   2016-04-20
 ---
 
 We are pleased to announce the release of OMERO.figure 1.2.1.


### PR DESCRIPTION
Preparing release blog post for figure 1.2.1
Staged at http://figure.staging.openmicroscopy.org/

Check the "blog" and "releases" links and blog post text

NB: Date of release will be updated to the actual release date before merging.