### PR TITLE
Disable save button

### DIFF
--- a/static/figure/figure.js
+++ b/static/figure/figure.js
@@ -2586,6 +2586,7 @@ var CropModalView = Backbone.View.extend({
                 event.preventDefault();
             }
             this.$saveBtn.tooltip('hide');
+            this.$saveBtn.attr('disabled', 'disabled');
             this.save_figure();
         },
 

--- a/static/figure/js/views/figure_view.js
+++ b/static/figure/js/views/figure_view.js
@@ -367,6 +367,7 @@
                 event.preventDefault();
             }
             this.$saveBtn.tooltip('hide');
+            this.$saveBtn.attr('disabled', 'disabled');
             this.save_figure();
         },
 


### PR DESCRIPTION
Simply disables the 'Save Figure' button right after the user clicks on it, to prevent multiple simultaneous save actions being triggered. See [Trello - Disable 'Save' when clicked](https://trello.com/c/mZsyPq8K/130-disable-save-when-clicked)
