### PR TITLE
OMERO_FIGURE_VERSION static variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figure",
-  "version": "1.2.1",
+  "version": "1.2.1_dev",
   "description": "OMERO figure creation app",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figure",
-  "version": "1.2.1_dev",
+  "version": "1.2.1-dev",
   "description": "OMERO figure creation app",
   "main": "index.js",
   "scripts": {

--- a/settings.py
+++ b/settings.py
@@ -5,4 +5,10 @@
 # https://www.openmicroscopy.org/
 #   site/support/omero5.2/developers/Web/CreateApp.html
 
-OMERO_FIGURE_VERSION = "1.2.1-dev"
+import json
+import os
+dir_path = os.path.dirname(os.path.realpath(__file__))
+package_path = os.path.join(dir_path, 'package.json')
+with open(package_path) as f:
+    data = json.load(f)
+OMERO_FIGURE_VERSION = data['version']

--- a/settings.py
+++ b/settings.py
@@ -5,4 +5,4 @@
 # https://www.openmicroscopy.org/
 #   site/support/omero5.2/developers/Web/CreateApp.html
 
-OMERO_FIGURE_VERSION = "1.2.1_dev"
+OMERO_FIGURE_VERSION = "1.2.1-dev"

--- a/settings.py
+++ b/settings.py
@@ -5,4 +5,4 @@
 # https://www.openmicroscopy.org/
 #   site/support/omero5.2/developers/Web/CreateApp.html
 
-OMERO_FIGURE_VERSION = "1.2.1"
+OMERO_FIGURE_VERSION = "1.2.1_dev"

--- a/settings.py
+++ b/settings.py
@@ -5,13 +5,4 @@
 # https://www.openmicroscopy.org/
 #   site/support/omero5.2/developers/Web/CreateApp.html
 
-
-def identity(x):
-    return x
-
-
-# import json
-CUSTOM_SETTINGS_MAPPINGS = {
-    "omero.web.figure.version":
-    ["OMERO_FIGURE_VERSION", "1.2.1", identity, None]
-}
+OMERO_FIGURE_VERSION = "1.2.1"


### PR DESCRIPTION
We don't need to make this a configurable setting since it is
fixed for each release.
Also, the CUSTOM_SETTINGS_MAPPINGS is handled differently in OMERO 5.0
meaning that OMERO.figure breaks on 5.0

See https://trello.com/c/p31jKBy1/124-omero-5-1-x-and-5-0-x-compatible

To test:
 - Check that the app still opens OK, and that ```Help > About``` shows OMERO.figure version 1.2.1-dev