### PR TITLE
Remove OMERO 4.4 support from install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This is a jekyll-powered site. To view:
     $ cd figure
     $ jekyll serve --watch
 
-    Go to http://localhost:4000
+    Go to http://localhost:4000/figure/
 
 
 To update figure.openmicroscopy.org site:

--- a/index.html
+++ b/index.html
@@ -126,8 +126,7 @@ title: OMERO.figure
               rename the unzipped directory to 'figure'.
             </li>
             <li>
-              Place 'figure' <strong>within</strong> a directory that is on your PYTHONPATH, or
-              in the OMERO <code style="display:inline">lib/python/omeroweb/</code> directory.
+              Place 'figure' <strong>within</strong> a directory that is on your PYTHONPATH.
             </li>
             <li>Add the app to OMERO.web:
               <code> $ bin/omero config append omero.web.apps '"figure"' &nbsp # NB: double quotes</code>

--- a/index.html
+++ b/index.html
@@ -120,27 +120,24 @@ title: OMERO.figure
         <h1>Install instructions</h1>
         <p>
           <ul>
+            <li>You need to be running OMERO.web 5.0 or later</li>
             <li>
               Download the release from the top of this page, unzip and
               rename the unzipped directory to 'figure'.
             </li>
             <li>
               Place 'figure' <strong>within</strong> a directory that is on your PYTHONPATH, or
-              in the OMERO <code style="display:inline">lib/python/omeroweb/</code> directory. NB: for OMERO 4.4.9 and earlier, you will
-              have to use lib/python/omeroweb/ (other locations not supported).
+              in the OMERO <code style="display:inline">lib/python/omeroweb/</code> directory.
             </li>
             <li>Add the app to OMERO.web:
               <code> $ bin/omero config append omero.web.apps '"figure"' &nbsp # NB: double quotes</code>
               NB: On Windows, you'll need to escape the inner double quotes:
-              <code> $ bin/omero config append omero.web.apps "\"figure\""</code>
-              NB: for OMERO 4.4.x you'll need to 'set' the whole list (append not supported):
-              <code> $ bin/omero config set omero.web.apps '["figure"]' &nbsp # OMERO 4.4 only</code>
+              <code> $ bin\omero config append omero.web.apps "\"figure\""</code>
             </li>
             <li>Display a link to 'Figure' at the top of the webclient: 
               <!-- with 'target' set to open the link in a new tab: -->
               <code style="width:650px">
                 $ bin/omero config append omero.web.ui.top_links '["Figure", "figure_index", {"title": "Open Figure in new tab", "target": "figure"}]'
-
               </code>
             </li>
             <li>Restart web. How you do this will depend on how you have deployed OMERO.web.


### PR DESCRIPTION
This removes install instructions for OMERO 4.4, which we don't test on now.
Clarifies that we support OMERO 5.0 and later. See: https://trello.com/c/p31jKBy1/124-omero-5-1-x-and-5-0-x-compatible