### PR TITLE
Add images button enabled

### DIFF
--- a/static/figure/figure.js
+++ b/static/figure/figure.js
@@ -3809,7 +3809,7 @@ var LegendView = Backbone.View.extend({
         events: {
             "submit .addIdForm": "previewSetId",
             "click .preview": "previewSetId",
-            "keyup .imgIds": "keyPressed",
+            "keyup .imgId": "keyPressed",
             "click .doSetId": "doSetId",
         },
 
@@ -3826,7 +3826,7 @@ var LegendView = Backbone.View.extend({
 
         // Only enable submit button when input has a number in it
         keyPressed: function() {
-            var idInput = $('input.imgIds', this.$el).val(),
+            var idInput = $('input.imgId', this.$el).val(),
                 previewBtn = $('button.preview', this.$el),
                 re = /^\d+$/;
             if (re.test(idInput)) {
@@ -3841,7 +3841,7 @@ var LegendView = Backbone.View.extend({
             event.preventDefault();
 
             var self = this,
-                idInput = $('input.imgIds', this.$el).val();
+                idInput = $('input.imgId', this.$el).val();
 
             // get image Data
             $.getJSON(BASE_WEBFIGURE_URL + 'imgData/' + parseInt(idInput, 10) + '/', function(data){
@@ -5311,7 +5311,7 @@ var RectView = Backbone.View.extend({
             event.preventDefault();
             // Simply show dialog - Everything else handled by SetIdModalView
             $("#setIdModal").modal('show');
-            $("#setIdModal .imgIds").val("").focus();
+            $("#setIdModal .imgId").val("").focus();
         },
 
         // just update x,y,w,h by rendering ONE template

--- a/static/figure/figure.js
+++ b/static/figure/figure.js
@@ -4002,6 +4002,7 @@ var LegendView = Backbone.View.extend({
             "submit .addImagesForm": "addImages",
             "click .btn-primary": "addImages",
             "keyup .imgIds": "keyPressed",
+            "paste .imgIds": "keyPressed",
         },
 
         initialize: function(options) {
@@ -4018,10 +4019,16 @@ var LegendView = Backbone.View.extend({
         },
 
         // Only enable submit button when input has a number in it
-        keyPressed: function() {
+        keyPressed: function(event) {
             var idInput = $('input.imgIds', this.$el).val(),
                 submitBtn = $('button.btn-primary', this.$el),
                 re = /\d.*/;
+            // Strangely if 'paste' event, value is not immediately set
+            // Try again after short timeout...
+            if (event && event.type === "paste") {
+                setTimeout(this.keyPressed, 50);
+                return;
+            }
             if (re.test(idInput)) {
                 submitBtn.removeAttr("disabled");
             } else {

--- a/static/figure/js/views/modal_views.js
+++ b/static/figure/js/views/modal_views.js
@@ -167,7 +167,7 @@
         events: {
             "submit .addIdForm": "previewSetId",
             "click .preview": "previewSetId",
-            "keyup .imgIds": "keyPressed",
+            "keyup .imgId": "keyPressed",
             "click .doSetId": "doSetId",
         },
 
@@ -184,7 +184,7 @@
 
         // Only enable submit button when input has a number in it
         keyPressed: function() {
-            var idInput = $('input.imgIds', this.$el).val(),
+            var idInput = $('input.imgId', this.$el).val(),
                 previewBtn = $('button.preview', this.$el),
                 re = /^\d+$/;
             if (re.test(idInput)) {
@@ -199,7 +199,7 @@
             event.preventDefault();
 
             var self = this,
-                idInput = $('input.imgIds', this.$el).val();
+                idInput = $('input.imgId', this.$el).val();
 
             // get image Data
             $.getJSON(BASE_WEBFIGURE_URL + 'imgData/' + parseInt(idInput, 10) + '/', function(data){
@@ -360,6 +360,7 @@
             "submit .addImagesForm": "addImages",
             "click .btn-primary": "addImages",
             "keyup .imgIds": "keyPressed",
+            "paste .imgIds": "keyPressed",
         },
 
         initialize: function(options) {

--- a/static/figure/js/views/modal_views.js
+++ b/static/figure/js/views/modal_views.js
@@ -377,10 +377,16 @@
         },
 
         // Only enable submit button when input has a number in it
-        keyPressed: function() {
+        keyPressed: function(event) {
             var idInput = $('input.imgIds', this.$el).val(),
                 submitBtn = $('button.btn-primary', this.$el),
                 re = /\d.*/;
+            // Strangely if 'paste' event, value is not immediately set
+            // Try again after short timeout...
+            if (event && event.type === "paste") {
+                setTimeout(this.keyPressed, 50);
+                return;
+            }
             if (re.test(idInput)) {
                 submitBtn.removeAttr("disabled");
             } else {

--- a/static/figure/js/views/right_panel_view.js
+++ b/static/figure/js/views/right_panel_view.js
@@ -711,7 +711,7 @@
             event.preventDefault();
             // Simply show dialog - Everything else handled by SetIdModalView
             $("#setIdModal").modal('show');
-            $("#setIdModal .imgIds").val("").focus();
+            $("#setIdModal .imgId").val("").focus();
         },
 
         // just update x,y,w,h by rendering ONE template

--- a/templates/figure/index.html
+++ b/templates/figure/index.html
@@ -300,7 +300,7 @@
                     <p>Choose a new Image ID for the selected panels</p>
                     <form class="setIdForm form-inline" role="form" style="margin-top: 10px; margin-bottom: 10px">
                         <div class="form-group">
-                            <input type="text" class="form-control imgIds" placeholder="Image ID">
+                            <input type="text" class="form-control imgId" placeholder="Image ID">
                         </div>
                         <button type="submit" class="btn btn-primary preview" disabled="disabled">Preview</button>
                     </form>


### PR DESCRIPTION
See https://trello.com/c/yCvoAOs5/132-add-images-button-not-enabled-on-edit-paste

To test:
 - With a new or existing figure, Add Images dialog. Use the right-click menu or browser top menu to Edit > Paste the image ID or URL.
 - The 'Add Images' button should become enabled if the pasted text contains image ID (number).
 - Add Images should then work as normal.